### PR TITLE
Passwords with special characters are broken

### DIFF
--- a/RDPassSpray.py
+++ b/RDPassSpray.py
@@ -195,13 +195,25 @@ def attempts(users, passes, targets, domain, output_file_name, hostnames_strippe
                                 "hostnamectl set-hostname '%s'" % hostnames_stripped[
                                     attempts_hostname_counter],
                                 shell=True)
-                        auth_param = "/p:\"%s\"" % (password)
+                        
+                        command = [
+                            "xfreerdp",
+                            f"/v:{target}",
+                            f"+auth-only",
+                            f"/d:{domain}",
+                            f"/u:{username}",
+                            "/sec:nla",
+                            "/cert-ignore"
+                        ]
+
                         if pass_the_hash:
-                            auth_param = "/p:\"\" /pth:\"%s\"" % (password) # /p is needed for +auth-only, even with /pth
-                        spray = subprocess.Popen(
-                            "xfreerdp /v:'%s' +auth-only /d:%s /u:%s %s /sec:nla /cert-ignore" %
-                            (target, domain, username, auth_param), stdout=subprocess.PIPE,
-                            stderr=subprocess.PIPE, shell=True)
+                            command.append("/p:") # /p is needed for +auth-only, even with /pth
+                            command.append(f"/pth:{password}")
+                        else:
+                            command.append(f"/p:{password}")
+
+                        spray = subprocess.Popen(command, stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE)
                         output_error = spray.stderr.read()
                         output_info = spray.stdout.read()
                         # throttling requests

--- a/RDPassSpray.py
+++ b/RDPassSpray.py
@@ -190,7 +190,7 @@ def attempts(users, passes, targets, domain, output_file_name, hostnames_strippe
                             shell=True)
                         spray = subprocess.Popen(
                             "xfreerdp /v:'%s' +auth-only /d:%s /u:%s /p:'%s' /sec:nla /cert-ignore" %
-                            (target, domain, username, password.replace("'","'\"'\"'"), stdout=subprocess.PIPE,
+                            (target, domain, username, password.replace("'","'\"'\"'")), stdout=subprocess.PIPE,
                             stderr=subprocess.PIPE, shell=True)
                         output_error = spray.stderr.read()
                         output_info = spray.stdout.read()

--- a/RDPassSpray.py
+++ b/RDPassSpray.py
@@ -189,8 +189,8 @@ def attempts(users, passes, targets, domain, output_file_name, hostnames_strippe
                                 attempts_hostname_counter],
                             shell=True)
                         spray = subprocess.Popen(
-                            "xfreerdp /v:'%s' +auth-only /d:%s /u:%s /p:\"%s\" /sec:nla /cert-ignore" %
-                            (target, domain, username, password), stdout=subprocess.PIPE,
+                            "xfreerdp /v:'%s' +auth-only /d:%s /u:%s /p:'%s' /sec:nla /cert-ignore" %
+                            (target, domain, username, password.replace("'","'\"'\"'"), stdout=subprocess.PIPE,
                             stderr=subprocess.PIPE, shell=True)
                         output_error = spray.stderr.read()
                         output_info = spray.stdout.read()

--- a/RDPassSpray.py
+++ b/RDPassSpray.py
@@ -198,19 +198,19 @@ def attempts(users, passes, targets, domain, output_file_name, hostnames_strippe
                         
                         command = [
                             "xfreerdp",
-                            f"/v:{target}",
-                            f"+auth-only",
-                            f"/d:{domain}",
-                            f"/u:{username}",
+                            "/v:%s" % target,
+                            "+auth-only",
+                            "/d:%s" % domain,
+                            "/u:%s" % username,
                             "/sec:nla",
                             "/cert-ignore"
                         ]
 
                         if pass_the_hash:
                             command.append("/p:") # /p is needed for +auth-only, even with /pth
-                            command.append(f"/pth:{password}")
+                            command.append("/pth:%s" % password)
                         else:
-                            command.append(f"/p:{password}")
+                            command.append("/p:%s" % password)
 
                         spray = subprocess.Popen(command, stdout=subprocess.PIPE,
                             stderr=subprocess.PIPE)


### PR DESCRIPTION
The proposed fix is to simply replace double quotes by single quotes as the double quotes in bash will interpret some special characters like exclamation mark and dollar sign. Also added single quote escaping for passwords containing single quotes.